### PR TITLE
Remove multiple definition of 'yylloc'

### DIFF
--- a/drivers/usb/gadget/function/u_ether.c
+++ b/drivers/usb/gadget/function/u_ether.c
@@ -28,6 +28,7 @@
 #include <linux/notifier.h>
 #include <linux/cpufreq.h>
 #include "u_ether.h"
+#include "rndis.h"
 
 
 /*

--- a/scripts/dtc/dtc-lexer.l
+++ b/scripts/dtc/dtc-lexer.l
@@ -39,8 +39,6 @@ LINECOMMENT	"//".*\n
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
-
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
 #define	YY_USER_ACTION \
 	{ \

--- a/scripts/dtc/dtc-lexer.lex.c_shipped
+++ b/scripts/dtc/dtc-lexer.lex.c_shipped
@@ -637,8 +637,6 @@ char *yytext;
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
-
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
 #define	YY_USER_ACTION \
 	{ \

--- a/scripts/dtc/dtc-parser.tab.h_shipped
+++ b/scripts/dtc/dtc-parser.tab.h_shipped
@@ -40,6 +40,8 @@
 extern int yydebug;
 #endif
 
+extern YYLTYPE yylloc;
+
 /* Tokens.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE


### PR DESCRIPTION
I was getting this while trying to `mka hybris-boot`:
    /usr/bin/ld: scripts/dtc/dtc-parser.tab.o:(.bss+0x50): multiple definition of 'yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here

Following [this](https://github.com/engstk/op5/commit/554ee62c761ecf54a772b5a10e1cda966912cc83), I removed the definition for `yylloc` from `dtc-lexer` and added it as an external definition in `dtc-parser-tab.h`.

This made the build succeed